### PR TITLE
Preserve names.arg values when set and let rev arg drive order to names.rg values

### DIFF
--- a/R/waterfallplot.R
+++ b/R/waterfallplot.R
@@ -170,8 +170,18 @@ waterfallplot <-
 	}
 	if (!is.null(names.arg) && length(names.arg) != l)
 		stop("incorrect number of names")
-	if (!is.null(names(height)))
-		names.arg <- names(height)
+	if (!is.null(names(height))){
+	  # if names.arg is present, use it (don't overwrite)
+	  # otherwise, use the names attribute of height
+	  if (is.null(names.arg)) {
+	    names.arg <- names(height)
+	  }
+
+	  # let the rev argument drive the order of names.arg
+	  if (rev == TRUE) {
+	    names.arg <- rev(names.arg)
+	  }
+    }
 	density.vec <- rep(density, l, length.out = l)
 	angle.vec <- rep(angle, l, length.out = l)
 	if (is.null(col))


### PR DESCRIPTION
Currently, when the user passes valid values into `names.arg`, those values are overwritten. As a result, output charts continue to show the values of `names(height)` even when new values are specified through `names.arg`. In this pull request, this issue is fixed. Valid values of `names.arg` are passed all the way through to the charts. In addition, if the user sets `rev=TRUE`, the order of `names.arg` is similarly reversed.